### PR TITLE
fix: enable WAL mode to eliminate event-loop stalls under concurrent load

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,20 @@ async function initSqliteCache(configuration: SqliteCacheConfiguration) {
     type === "bun"
       ? new Database(configuration.database, { strict: true })
       : new Database(configuration.database);
+
+  // Enable WAL mode for file-based databases. Without WAL, every write
+  // (including cache.get() which updates lastAccess) triggers two fsyncs via
+  // the rollback journal. Under concurrent load from multiple processes this
+  // serialises on the write lock — each waiter blocks its Node.js event loop
+  // for the full busy-timeout duration, producing 200-500 ms stalls.
+  // WAL + synchronous=NORMAL writes append to the WAL file with no per-write
+  // fsync, reducing individual write latency by ~10-15× and eliminating the
+  // contention-cascade that causes those stalls.
+  if (configuration.database !== ":memory:") {
+    db.exec("PRAGMA journal_mode=WAL");
+    db.exec("PRAGMA synchronous=NORMAL");
+  }
+
   const cacheTableName = configuration.cacheTableName ?? "cache";
   const escapedTableName = escapeIdentifier(cacheTableName);
 


### PR DESCRIPTION
## Problem

Without WAL mode, every write to the cache — including \`cache.get()\`, which updates \`lastAccess\` on every call — uses the rollback journal and triggers **two fsyncs** (one for the journal, one for the main file).

When multiple Node.js cluster workers share the same database file, they serialise on the SQLite write lock. Because \`better-sqlite3\` defaults to a **5 second busy-timeout**, each waiting worker spins synchronously, **blocking its event loop** for the entire wait duration.

With e.g. 10 workers each running the built-in 1-second cleanup interval (\`setInterval(checkForExpiredItems, 1000)\`), the last worker can wait up to 9 × (per-cleanup I/O time). On cloud storage (e.g. Hetzner Ceph-backed volumes, ~2–5 ms per fsync), this produces **200–500 ms event-loop stalls** — confirmed in production profiling where every steady-state block traced back to \`SqliteCache.checkForExpiredItems\`.

## Fix

Enable WAL mode + \`synchronous=NORMAL\` immediately after opening the database:

\`\`\`sql
PRAGMA journal_mode=WAL;
PRAGMA synchronous=NORMAL;
\`\`\`

WAL appends writes to the WAL file with **no per-write fsync**, reducing individual write latency by ~10–15× and breaking the contention cascade entirely. The pragma is skipped for \`:memory:\` databases where WAL does not apply.

## Result

| | p50 | p95 | notes |
|---|---|---|---|
| Before (delete journal) | 0.27 ms | 0.44 ms | local SSD — ~2.4 ms on cloud storage |
| After (WAL + NORMAL) | 0.02 ms | 0.03 ms | no fsync per write |

All 25 existing tests pass unchanged.